### PR TITLE
TV-10933 TV-10935 Fix record/showMore not tappable on mobile

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -417,8 +417,6 @@ export default class ReactCalendarTimeline extends Component {
       this.singleTouchStart = null
       this.lastSingleTouch = null
     } else if (e.touches.length === 1) {
-      e.preventDefault()
-
       let x = e.touches[0].clientX
       let y = e.touches[0].clientY
 
@@ -478,8 +476,6 @@ export default class ReactCalendarTimeline extends Component {
       this.lastTouchDistance = null
     }
     if (this.lastSingleTouch) {
-      e.preventDefault()
-
       this.lastSingleTouch = null
       this.singleTouchStart = null
     }


### PR DESCRIPTION
Removing e.preventDefault() in touchStart fixes the record tap.
Removing e.preventDefault()in touchEnd fixes the show more tap.