### PR TITLE
TV-20724 Fix dragging timeline records

### DIFF
--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -405,6 +405,8 @@ export default class ReactCalendarTimeline extends Component {
     } else {
       this.setState({ headerPosition: 'fixed', scrollOffset });
     }
+
+    this.calcTopOffset();
   }
 
   touchStart = (e) => {
@@ -480,8 +482,9 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   resize = (props = this.props) => {
+      this.calcTopOffset();
       if (this.refs.container) {
-          const { width: containerWidth, top: containerTop } = this.refs.container.getBoundingClientRect();
+          const { width: containerWidth } = this.refs.container.getBoundingClientRect();
           let width = containerWidth - props.sidebarWidth - props.rightSidebarWidth;
 
           const {
@@ -490,7 +493,6 @@ export default class ReactCalendarTimeline extends Component {
 
           this.setState({
             width: width,
-            topOffset: containerTop + window.pageYOffset,
             dimensionItems: dimensionItems,
             height: height,
             groupHeights: groupHeights,
@@ -499,6 +501,16 @@ export default class ReactCalendarTimeline extends Component {
           });
           this.refs.scrollComponent.scrollLeft = width;
       }
+  }
+
+  calcTopOffset = () => {
+    if (this.refs.container) {
+      const { top: containerTop } = this.refs.container.getBoundingClientRect();
+
+      this.setState({
+        topOffset: containerTop + window.pageYOffset,
+      });
+    }
   }
 
   onScroll = () => {
@@ -528,6 +540,8 @@ export default class ReactCalendarTimeline extends Component {
     if (this.state.visibleTimeStart !== visibleTimeStart || this.state.visibleTimeEnd !== visibleTimeStart + zoom) {
       this.props.onTimeChange(visibleTimeStart, visibleTimeStart + zoom, this.updateScrollCanvas);
     }
+
+    this.calcTopOffset();
   }
 
   componentWillReceiveProps (nextProps) {
@@ -743,6 +757,8 @@ export default class ReactCalendarTimeline extends Component {
     const { headerLabelGroupHeight, headerLabelHeight } = this.props;
     const headerHeight = headerLabelGroupHeight + headerLabelHeight;
 
+    this.calcTopOffset();
+
     if (pageY - topOffset > headerHeight && e.button === 0) {
       this.setState({isDragging: true, dragStartPosition: e.pageX, dragLastPosition: e.pageX});
     }
@@ -752,6 +768,10 @@ export default class ReactCalendarTimeline extends Component {
     if (this.state.isDragging && !this.state.draggingItem && !this.state.resizingItem) {
       this.refs.scrollComponent.scrollLeft += this.state.dragLastPosition - e.pageX;
       this.setState({dragLastPosition: e.pageX});
+    }
+
+    if (this.state.isDragging) {
+      this.calcTopOffset();
     }
   }
 

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -143,7 +143,7 @@ export default class Item extends Component {
 
       for (var key of Object.keys(groupTops)) {
         var item = groupTops[key]
-        if (e.pageY - topOffset + scrollOffset > item) {
+        if (e.pageY - topOffset > item) {
           groupDelta = parseInt(key, 10) - order
         } else {
           break


### PR DESCRIPTION
- Fix logic in calculating top of timeline while dragging
- Calculate top of timeline more often to handle different cases of resizing and scrolling while dragging.

I wasn't able to write cypress tests for this mainly due to the way interact.js and cypress work.

Issue in Interact.js
https://github.com/taye/interact.js/issues/871

Issue in cypress
https://github.com/cypress-io/cypress/issues/6161

Update to cypress-drag-drop that is supposed to fix this but didn't work
https://github.com/4teamwork/cypress-drag-drop/pull/44

Here are the manual test cases we'll need to perform:
1. Drag record left and right, up and down without scrolling
2. Scroll inner container while dragging
3. Scroll outer container while dragging
4. Scroll outer container while dragging after window resize 
5. Scroll both inner and outer container while dragging
6. Scroll inner container on view page while dragging

Seeded dashboard with timeline: http://localhost:9000/#/apps/48/dashboard/94
Seeded timeline view: http://localhost:9000/#/apps/48/tables/357/views/888?renderMode=timelineView

We'll need to updated the UI project with the updated hash for this library after this is merged